### PR TITLE
capture missing edge data

### DIFF
--- a/compactor.js
+++ b/compactor.js
@@ -12,7 +12,9 @@ function findNextEnd(prev, v, vertices, ends, vertexCoords, edgeData, trackIncom
         path = [],
         reducedEdge = options.edgeDataSeed;
         
-    reducedEdge = options.edgeDataReduceFn(reducedEdge, edgeData[v][prev]);
+    if (options.edgeDataReduceFn) {
+        reducedEdge = options.edgeDataReduceFn(reducedEdge, edgeData[v][prev]);
+    }
 
     while (!ends[v]) {
         var edges = vertices[v];

--- a/compactor.js
+++ b/compactor.js
@@ -11,6 +11,8 @@ function findNextEnd(prev, v, vertices, ends, vertexCoords, edgeData, trackIncom
         coordinates = [],
         path = [],
         reducedEdge = options.edgeDataSeed;
+        
+    reducedEdge = options.edgeDataReduceFn(reducedEdge, edgeData[v][prev]);
 
     while (!ends[v]) {
         var edges = vertices[v];

--- a/test/network.json
+++ b/test/network.json
@@ -937,6 +937,26 @@
             ]
          }
       },
+      {
+         "type":"Feature",
+         "properties":{
+            "id":2001,
+            "lastUpdate":"2016-03-19"
+         },
+         "geometry":{
+            "type": "LineString",
+            "coordinates":[
+               [
+                  8.42652926,
+                  59.50263377
+               ],
+               [
+                  8.42620233,
+                  59.50276093
+               ]
+            ]
+         }
+      },
       {  
          "type":"Feature",
          "properties":{  
@@ -946,10 +966,6 @@
          "geometry":{  
             "type":"LineString",
             "coordinates":[  
-               [  
-                  8.42652926,
-                  59.50263377
-               ],
                [  
                   8.42620233,
                   59.50276093

--- a/test/pathSpec.js
+++ b/test/pathSpec.js
@@ -170,7 +170,30 @@ test('can reduce data on edges', function(t) {
 
     t.ok(path, 'has path');
     t.ok(path.edgeDatas, 'has edge datas');
-    t.ok(path.edgeDatas.every(function(e) { return e; }))
+    t.ok(path.edgeDatas.every(function(e) { return e; }));
+
+    t.end();
+});
+
+function edgeReduce(a, p) {
+  const p_arr = [p.id];
+  const a_arr = (a && a.id) ? [...a.id] : [];
+
+  const arr = Array.from(new Set([...p_arr, ...a_arr]));
+  return { id: [].concat(...arr) };
+}
+
+test('captures all edge data', function(t) {
+    var pathfinder = new PathFinder(geojson, {
+            edgeDataReduceFn: edgeReduce,
+            edgeDataSeed: -1
+        }),
+        path = pathfinder.findPath(point([8.44460166,59.48947469]), point([8.44651,59.513920000000006]));
+
+    t.ok(path, 'has path');
+    console.log(JSON.stringify(path.edgeDatas));
+    t.ok(path.edgeDatas, 'has edge datas');
+    t.ok(path.edgeDatas.some(function(e) { console.log(e); console.log(e.reducedEdge.id.indexOf(2001) >-1); return (e.reducedEdge.id.indexOf(2001) >-1); }));
 
     t.end();
 });

--- a/test/pathSpec.js
+++ b/test/pathSpec.js
@@ -176,11 +176,15 @@ test('can reduce data on edges', function(t) {
 });
 
 function edgeReduce(a, p) {
-  const p_arr = [p.id];
-  const a_arr = (a && a.id) ? [...a.id] : [];
-
-  const arr = Array.from(new Set([...p_arr, ...a_arr]));
-  return { id: [].concat(...arr) };
+    var a_arr = (a && a.id) ? a.id : [];
+    if(typeof p.id === 'number') {
+        a_arr.push(p.id);
+    } else {
+        p.id.forEach(function (id) {
+            a_arr.push(id);
+        });
+    }
+    return { id: Array.from(new Set(a_arr)) };
 }
 
 test('captures all edge data', function(t) {
@@ -191,9 +195,8 @@ test('captures all edge data', function(t) {
         path = pathfinder.findPath(point([8.44460166,59.48947469]), point([8.44651,59.513920000000006]));
 
     t.ok(path, 'has path');
-    console.log(JSON.stringify(path.edgeDatas));
     t.ok(path.edgeDatas, 'has edge datas');
-    t.ok(path.edgeDatas.some(function(e) { console.log(e); console.log(e.reducedEdge.id.indexOf(2001) >-1); return (e.reducedEdge.id.indexOf(2001) >-1); }));
+    t.ok(path.edgeDatas.some(function(e) { return (e.reducedEdge.id.indexOf(2001) >-1); }));
 
     t.end();
 });


### PR DESCRIPTION
First of all, fantastic library!

I found a small issue that the library was not capturing all edge data.

As an example, for each route I was collecting the unique ID's from each road segment. I would then filter my overall network by the captured ID's in QGIS, and I found there were gaps.

<img width="1428" alt="before" src="https://user-images.githubusercontent.com/3753295/36169678-8cd6599a-10c2-11e8-9dbc-79a5c5c1658f.png">

Adding the line in this PR ensured that all edges were captured, and I no longer had any gaps.

<img width="1348" alt="after" src="https://user-images.githubusercontent.com/3753295/36169687-93f18ccc-10c2-11e8-851b-80d2a5871103.png">
