### PR TITLE
Fix map overlapping content on Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
         }
 
         .content {
-            position: relative;
+            position: absolute;
+            width: 100%;
             top: 55%;
             border-top: 2px solid rgba(0, 0, 0. 0.4);
         }


### PR DESCRIPTION
Hey, you have a layout problem with Firefox. Here is the before and after with the fix.

<img width="682" alt="Screenshot 2019-09-21 at 10 05 08" src="https://user-images.githubusercontent.com/1055960/65369560-708c0200-dc57-11e9-8b9d-57109cf332ed.png">
<img width="682" alt="Screenshot 2019-09-21 at 10 05 22" src="https://user-images.githubusercontent.com/1055960/65369559-708c0200-dc57-11e9-886d-0e1c556bd902.png">

