### PR TITLE
Small updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ you can find a path from one feature to the other.
 To find the shortest path between two coordinates:
 
 ```javascript
-var path = pathfinder.findPath(start, finish);
+var path = pathFinder.findPath(start, finish);
 ```
 
 Where `start` and `finish` are two GeoJSON `point` features.
 
 If a route can be found, an object with two properties: `path` and `weight` is returned, where `path` 
-is the coordinates the path runs through, and `weight` is the total weight (distance, if you use the default weight function) of the path.
+is the coordinates the path runs through, and `weight` is the total weight (distance in kilometers, if you use the default weight function) of the path.
 
 ### `PathFinder` options
 


### PR DESCRIPTION
A couple very small updates to the README:

1. I was testing out the library and copy-pasting the example didn't work because of `pathfinder` vs `pathFinder`
2. I originally expected `weight` to be returned in the same units as provided, i.e. degrees. It looks the default `weightFn` is `turf.distance`, whose default is kilometers, so I thought it would be helpful if the Readme specified the unit of the default `weightFn`.
