### PR TITLE
Add compact option which can be used to prevent graph compacting

### DIFF
--- a/compactor.js
+++ b/compactor.js
@@ -86,7 +86,9 @@ function compactGraph(vertices, vertexCoords, edgeData, options) {
         var numberEdges = edges.length;
         var remove;
 
-        if (numberEdges === 1) {
+        if(options.compact === false) {
+            remove = false;
+        } else if (numberEdges === 1) {
             var other = vertices[edges[0]];
             remove = !other[k];
         } else if (numberEdges === 2) {

--- a/compactor.js
+++ b/compactor.js
@@ -86,7 +86,7 @@ function compactGraph(vertices, vertexCoords, edgeData, options) {
         var numberEdges = edges.length;
         var remove;
 
-        if (options.compact === false) {
+        if (options.compact !== undefined && !options.compact) {
             remove = false;
         } else if (numberEdges === 1) {
             var other = vertices[edges[0]];

--- a/compactor.js
+++ b/compactor.js
@@ -86,7 +86,7 @@ function compactGraph(vertices, vertexCoords, edgeData, options) {
         var numberEdges = edges.length;
         var remove;
 
-        if(options.compact === false) {
+        if (options.compact === false) {
             remove = false;
         } else if (numberEdges === 1) {
             var other = vertices[edges[0]];


### PR DESCRIPTION
This relates to issue #27.

Am using geojson-path-finder in my OpenTrailView project (opentrailview.org) which is a StreetView-like application for hiking trails. Panoramas are auto-linked using underlying OpenStreetMap data in the form of GeoJSON, and geojson-path-finder is used to find routes between adjacent panoramas to allow such linking.

The distance between panoramas is typically small (maybe between 10 and 100 metres) and only a small area of GeoJSON is downloaded to calculate the routing. I found that with unmodified geojson-path-finder, the graph would be compacted leading to incorrect routing between adjacent panoramas. Modifiying the precision parameter didn't appear to solve the problem.

By making this small modification (allowing compacting to be turned off in cases like this where the graph is very small by setting the 'compact' option to false), the problem disappeared.

Usage is simple:

var pathFinder = new PathFinder(json, { compact: false } );

Obviously I can see why compacting is desirable in larger graphs, but in this specific use case, I need to route over a very small graph and keeping the graph uncompacted is vital to obtain the correct results.