### PR TITLE
add findNearestJunction() method to find the nearest junction vertex to a given point

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
 var findPath = require('./dijkstra'),
     preprocess = require('./preprocessor'),
     compactor = require('./compactor'),
-    roundCoord = require('./round-coord');
+    roundCoord = require('./round-coord'),
+    distance = require('@turf/distance').default,
+    point = require('turf-point');
 
 module.exports = PathFinder;
 
@@ -76,6 +78,23 @@ PathFinder.prototype = {
 
     serialize: function() {
         return this._graph;
+    },
+
+    findNearestJunction: function(p) {
+        var vertex = [ null, Number.MAX_VALUE ];
+        var junctions = Object.keys(this._graph.vertices).filter ( (function(k) {
+            var nEdges = Object.keys(this._graph.vertices[k]).length;
+            return nEdges >= 3 || nEdges == 1;
+        }).bind(this));
+
+        junctions.forEach( (function(k) {
+            const dist = distance(point(p), point(this._graph.sourceVertices[k]));
+            if(dist < vertex[1]) {
+                vertex[1] = dist;
+                vertex[0] = this._graph.sourceVertices[k].slice(0);
+            }
+        }).bind(this));
+        return vertex;
     },
 
     _createPhantom: function(n) {


### PR DESCRIPTION
This pull request is from a separate branch 'junctionfinder' of my fork of geojson-path-finder. It's independent to #64.

It adds the functionality to find the nearest 'junction vertex' of the graph to a given point,
This is useful if, for any reason, you need to 'snap' a point to a junction vertex. I have defined junction vertices as either those with three or more edges, or, conversely, those with just one edge, which are also likely to be potentially interesting.

I use this functionality for two separate use-cases, so thought it might be useful to add to GeoJSON Path Finder.

The first use-case is a panorama application, in which 360 panoramas are connected by GeoJSON Path Finder-derived routes; snapping panoramas to the nearest junction (if the panorama is very close to a junction) will mean that it will be linked correctly to *all* adjacent panoramas. The other is an augmented reality application in which I need to detect the location of path junctions so that I can create virtual signposts to nearby points of interest (again using GeoJSON Path Finder to route to those POIs).