### PR TITLE
Issue 27 fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,10 +90,8 @@ PathFinder.prototype = {
         }
 
         Object.keys(phantom.incomingEdges).forEach(function(neighbor) {
-            var neighborKeys = Object.keys(this._graph.compactedCoordinates[neighbor]);
-            var neighborExactPos = neighborKeys.length > 0 ? this._graph.compactedCoordinates[neighbor][neighborKeys[0]][0] : neighbor.split(',').map(function(v) { return parseFloat(v); });
             this._graph.compactedVertices[neighbor][n] = phantom.incomingEdges[neighbor];
-            this._graph.compactedCoordinates[neighbor][n] = [neighborExactPos].concat(phantom.incomingCoordinates[neighbor].slice(0, -1));
+            this._graph.compactedCoordinates[neighbor][n] = [this._graph.sourceVertices[neighbor]].concat(phantom.incomingCoordinates[neighbor].slice(0, -1));
             if (this._graph.compactedEdges) {
                 this._graph.compactedEdges[neighbor][n] = phantom.reducedEdges[neighbor];
             }

--- a/index.js
+++ b/index.js
@@ -90,8 +90,10 @@ PathFinder.prototype = {
         }
 
         Object.keys(phantom.incomingEdges).forEach(function(neighbor) {
+            var neighborKeys = Object.keys(this._graph.compactedCoordinates[neighbor]);
+            var neighborExactPos = neighborKeys.length > 0 ? this._graph.compactedCoordinates[neighbor][neighborKeys[0]][0] : neighbor.split(',').map(function(v) { return parseFloat(v); });
             this._graph.compactedVertices[neighbor][n] = phantom.incomingEdges[neighbor];
-            this._graph.compactedCoordinates[neighbor][n] = phantom.incomingCoordinates[neighbor];
+            this._graph.compactedCoordinates[neighbor][n] = [neighborExactPos].concat(phantom.incomingCoordinates[neighbor].slice(0, -1));
             if (this._graph.compactedEdges) {
                 this._graph.compactedEdges[neighbor][n] = phantom.reducedEdges[neighbor];
             }


### PR DESCRIPTION
(*Please note this is a new version of now-closed PR #64, now based on the `issue-27-fix` branch of my fork, as I wish to make other unrelated changes to master.*)

This is a likely fix of issue #27, which works in my test case, OpenTrailView (https://opentrailview.org) which uses GeoJSON Path Finder to connect together panoramas using GeoJSON OpenStreetMap data.

The issue appears to be when a phantom node is created for the end point of a route. The compactedCoordinates from the previous 'real' node (the neighbor) to the phantom node should contain the previous 'real' node, and not the phantom node - but in fact contain the reverse.

This happens because the incomingCoordinates of the phantom from the neighbor contain the phantom, but not the neighbor.

So the fix creates the compactedCoordinates by obtaining the neighbor coordinates (the exact unrounded coordinates of the neighbor are obtained) and concatenating the incomingCoordinates with the last member (the phantom coordinates) removed.