### PR TITLE
Add vertex keys to edges of calculated route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,10 +89,14 @@ export default class PathFinder<TEdgeReduce, TProperties> {
                 ) => {
                   if (index > 0) {
                     edges.push(
+                      Object.assign({
+                        v1: vertexKeys[index-1],
+                        v2: vertexKey
+                      },
                       this.graph.compactedEdges[vertexKeys[index - 1]][
                         vertexKey
                       ]
-                    );
+                    ));
                   }
 
                   return edges;


### PR DESCRIPTION
This is a small change to `index.ts` to add the vertex keys to the `edgeDatas` of each edge of the calculated route.

Why is this useful? It allows an approximate calculation of the distance of each edge on the route. For my use case (an augmented-reality walking app), I wish to calculate what proportion of the route is on footpaths (trails), and reject the route if the proportion is below a certain value. Adding the vertex keys to each edge allows this.

Tested (on my own app, https://github.com/nickw1/hikar.js) and it works, I also displayed each `edgeData` on the console, and it shows up as expected.
