### PR TITLE
Upgrade to turf 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
-        "@turf/distance": "^6.5.0",
-        "@turf/explode": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
+        "@turf/distance": "^7.2.0",
+        "@turf/explode": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
         "tinyqueue": "^2.0.3"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
+        "@types/geojson": "^7946.0.15",
         "@types/node": "^18.11.7",
         "esm": "^3.2.25",
         "typedoc": "^0.23.22",
@@ -382,54 +383,70 @@
       "dev": true
     },
     "node_modules/@turf/distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.2.0.tgz",
+      "integrity": "sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==",
+      "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/explode": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-6.5.0.tgz",
-      "integrity": "sha512-6cSvMrnHm2qAsace6pw9cDmK2buAlw8+tjeJVXMfMyY+w7ZUi1rprWMsY92J7s2Dar63Bv09n56/1V7+tcj52Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.2.0.tgz",
+      "integrity": "sha512-jyMXg93J1OI7/65SsLE1k9dfQD3JbcPNMi4/O3QR2Qb3BAs2039oFaSjtW+YqhMqVC4V3ZeKebMcJ8h9sK1n+A==",
+      "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
+      "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
+      "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
+      "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+      "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -449,6 +466,12 @@
       "dependencies": {
         "@types/chai": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.15",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
+      "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.11.7",
@@ -910,6 +933,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -1300,42 +1329,53 @@
       "dev": true
     },
     "@turf/distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.2.0.tgz",
+      "integrity": "sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==",
       "requires": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "@turf/explode": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-6.5.0.tgz",
-      "integrity": "sha512-6cSvMrnHm2qAsace6pw9cDmK2buAlw8+tjeJVXMfMyY+w7ZUi1rprWMsY92J7s2Dar63Bv09n56/1V7+tcj52Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.2.0.tgz",
+      "integrity": "sha512-jyMXg93J1OI7/65SsLE1k9dfQD3JbcPNMi4/O3QR2Qb3BAs2039oFaSjtW+YqhMqVC4V3ZeKebMcJ8h9sK1n+A==",
       "requires": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "requires": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      }
     },
     "@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
+      "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
       "requires": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
+      "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
       "requires": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10"
       }
     },
     "@types/chai": {
@@ -1352,6 +1392,11 @@
       "requires": {
         "@types/chai": "*"
       }
+    },
+    "@types/geojson": {
+      "version": "7946.0.15",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
+      "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA=="
     },
     "@types/node": {
       "version": "18.11.7",
@@ -1699,6 +1744,11 @@
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
       "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
       "dev": true
+    },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   "author": "Per Liedman <per@liedman.net>",
   "license": "ISC",
   "dependencies": {
-    "@turf/distance": "^6.5.0",
-    "@turf/explode": "^6.5.0",
-    "@turf/helpers": "^6.5.0",
+    "@turf/distance": "^7.2.0",
+    "@turf/explode": "^7.2.0",
+    "@turf/helpers": "^7.2.0",
     "tinyqueue": "^2.0.3"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
+    "@types/geojson": "^7946.0.15",
     "@types/node": "^18.11.7",
     "esm": "^3.2.25",
     "typedoc": "^0.23.22",

--- a/src/compactor.ts
+++ b/src/compactor.ts
@@ -1,4 +1,4 @@
-import { Position } from "@turf/helpers";
+import { Position } from "geojson";
 import { Coordinates, PathFinderOptions, Vertices, Key } from "./types";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
+import { lineString } from "@turf/helpers";
 import {
   Feature,
   FeatureCollection,
-  lineString,
+  GeoJsonProperties,
   LineString,
   Point,
   Position,
-} from "@turf/helpers";
+} from "geojson";
 import { compactNode } from "./compactor";
 import findPath from "./dijkstra";
 import preprocess from "./preprocessor";
@@ -13,7 +14,10 @@ import roundCoord from "./round-coord";
 import { defaultKey } from "./topology";
 import { Key, Path, PathFinderGraph, PathFinderOptions } from "./types";
 
-export default class PathFinder<TEdgeReduce, TProperties> {
+export default class PathFinder<
+  TEdgeReduce,
+  TProperties extends GeoJsonProperties
+> {
   graph: PathFinderGraph<TEdgeReduce>;
   options: PathFinderOptions<TEdgeReduce, TProperties>;
 

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,5 +1,11 @@
 import distance from "@turf/distance";
-import { FeatureCollection, LineString, point, Position } from "@turf/helpers";
+import { point } from "@turf/helpers";
+import {
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  Position,
+} from "geojson";
 import type {
   PathFinderGraph,
   PathFinderOptions,
@@ -10,8 +16,11 @@ import type {
 import compactGraph from "./compactor";
 import createTopology from "./topology";
 
-export default function preprocess<TEdgeReduce, TProperties>(
-  network: FeatureCollection<LineString, TProperties>,
+export default function preprocess<
+  TEdgeReduce,
+  TProperties extends GeoJsonProperties
+>(
+  network: FeatureCollection<Geometry, TProperties>,
   options: PathFinderOptions<TEdgeReduce, TProperties> = {}
 ): PathFinderGraph<TEdgeReduce> {
   const topology = createTopology(network, options);

--- a/src/round-coord.ts
+++ b/src/round-coord.ts
@@ -1,4 +1,4 @@
-import { Position } from "@turf/helpers";
+import { Position } from "geojson";
 
 export default function roundCoord(
   coord: Position,

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -1,25 +1,33 @@
+import { featureCollection } from "@turf/helpers";
 import {
-  AllGeoJSON,
+  GeoJSON,
   Feature,
-  featureCollection,
   FeatureCollection,
   LineString,
   Position,
-} from "@turf/helpers";
+  Geometry,
+  GeoJsonProperties,
+} from "geojson";
 import explode from "@turf/explode";
 import roundCoord from "./round-coord";
 import { Edge, PathFinderOptions, Topology } from "./types";
 
-export default function createTopology<TEdgeData, TProperties>(
-  network: FeatureCollection<LineString, TProperties>,
+export default function createTopology<
+  TEdgeData,
+  TProperties extends GeoJsonProperties
+>(
+  network: FeatureCollection<Geometry, TProperties>,
   options: PathFinderOptions<TEdgeData, TProperties> = {}
 ): Topology<TProperties> {
   const { key = defaultKey } = options;
   const { tolerance = 1e-5 } = options;
   const lineStrings = featureCollection(
-    network.features.filter((f) => f.geometry.type === "LineString")
+    network.features.filter(
+      (f): f is Feature<LineString, TProperties> =>
+        f.geometry.type === "LineString"
+    )
   );
-  const points = explode(lineStrings as AllGeoJSON);
+  const points = explode(lineStrings as GeoJSON);
   const vertices = points.features.reduce(function buildTopologyVertices(
     coordinates,
     feature,
@@ -63,7 +71,7 @@ export default function createTopology<TEdgeData, TProperties>(
   }
 }
 
-function geoJsonReduce<T, G, P>(
+function geoJsonReduce<T, G extends Geometry, P>(
   geojson: FeatureCollection<G, P> | Feature<G, P>,
   fn: (accumulator: T, feature: Feature<G, P>) => T,
   seed: T

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Position } from "@turf/helpers";
+import { Position } from "geojson";
 
 /**
  * Vertex key, a unique identifier for a vertex of a graph


### PR DESCRIPTION
This upgrades the turf dependencies to version 7.0.0 and adjusts types accordingly. See #93.

Feedback on this PR is welcome, since I don't personally use geojson-path-finder in any project where I can upgrade to turf 7.0.0.